### PR TITLE
Use JSON instead of Pandoc native format

### DIFF
--- a/bin/lunamark
+++ b/bin/lunamark
@@ -524,7 +524,7 @@ if inp:find("\r",1,true) then
   inp = inp:gsub("\r\n","\n") -- convert DOS line endings
 end
 
-local inp_pandoc = lunamark.util.pipe("pandoc -f markdown -t native", inp)
+local inp_pandoc = lunamark.util.pipe("pandoc -f markdown -t json", inp)
 local body, metadata = parse(inp_pandoc)
 
 local standalone = optarg.s

--- a/lunamark/reader/pandoc_ast.lua
+++ b/lunamark/reader/pandoc_ast.lua
@@ -3,6 +3,7 @@
 
 local util = require("lunamark.util")
 local lpeg = require("lpeg")
+local json = require("json")
 local entities = require("lunamark.entities")
 local lower, upper, gsub, format, length =
   string.lower, string.upper, string.gsub, string.format, string.len

--- a/rockspec.in
+++ b/rockspec.in
@@ -22,7 +22,8 @@ dependencies = {
    "lpeg >= 0.10",
    "cosmo >= 10.0",
    "alt-getopt >= 0.7",
-   "luautf8 >= 0.1.1"
+   "luautf8 >= 0.1.1",
+   "rxi-json-lua == e1dbe93-0"
 }
 build = {
    type = "none",


### PR DESCRIPTION
This PR adds [rxi/json.lua](https://github.com/rxi/json.lua) as a dependency and replaces Pandoc's native format for serializing [the AST](https://pandoc.org/using-the-pandoc-api.html) with an easier-to-parse JSON.