### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: Test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+  test:
+    name: Install Lunamark and test Pandoc JSON reader
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install additional packages
+        run: |
+          set -ex
+          sudo apt -qy update
+          sudo apt -qy install pandoc lua5.1 liblua5.1-dev luarocks tidy
+          sudo luarocks install diff
+          sudo luarocks install luafilesystem
+      - name: Install Lunamark
+        run: sudo luarocks make
+      - name: Test Pandoc JSON reader
+        run: bin/shtest --prog 'lunamark -f pandoc_json' --dir tests/basic --tidy

--- a/lunamark/reader/pandoc_json.lua
+++ b/lunamark/reader/pandoc_json.lua
@@ -1,4 +1,4 @@
-local json = require("json")
+local json = require("rxi-json-lua")
 local util = require("lunamark.util")
 
 local M = {}


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow and changes `require("json")` to `require("rxi-json-lua")`. Currently, the GitHub Actions workflow uses [the `ubuntu:latest` docker image](https://hub.docker.com/layers/ubuntu/library/ubuntu/latest/images/sha256-5403064f94b617f7975a19ba4d1a1299fd584397f6ee4393d0e16744ed11aab1?context=explore). If you'd like, you can try and rewrite the workflow using [`fedora:latest`](https://hub.docker.com/layers/fedora/library/fedora/latest/images/sha256-89301dcc9da5fc357301f53c0a8a76ec4988d34eb14f117f242704987e9e5800?context=explore).